### PR TITLE
Remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "mocha -mocha --require ts-node/register --require @babel/polyfill --require @babel/register './test/**/*.js'",
     "build": "tsc",
     "preinstall": "npm install --ignore-scripts",
-    "prepublish": "npm run build",
-    "postinstall": "npm run build"
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Because of the postinstall script in `@verida/wallet-utils` library, the installation of `@verida/datastore` would always fail. This PR removes the postinstall script as it was never necessary in the first place.